### PR TITLE
add `.gitmodules` file for existing submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule ".config/bat/themes/enki-theme"]
+	path = .config/bat/themes/enki-theme
+	url = https://github.com/enkia/enki-theme.git
+[submodule ".config/kitty/kitty-themes"]
+	path = .config/kitty/kitty-themes
+	url = https://github.com/dexpota/kitty-themes.git

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ First, install [homebrew](https://brew.sh/).
 Then run:
 
 ```bash
-git clone https://github.com/dlvhdr/dotfiles.git ~/dotfiles
+git clone --recursive https://github.com/dlvhdr/dotfiles.git ~/dotfiles
 cd ~/dotfiles
 ./setup/setup.sh
 ```


### PR DESCRIPTION
The `.config/bat/themes/enki-theme`[^1] and `.config/kitty/kitty-themes`[^2] submodules were added without a corresponding `.gitmodules` file.

This pull request adds the needed `.gitmodules` file and adds `--recursive` to the `git clone` instructions to ensure new copies of the repository contain this content.

[^1]: df56b6e48d
[^2]: 7b0f17d9a7